### PR TITLE
Tweaks

### DIFF
--- a/src/app/casedetail/casedetail.page.html
+++ b/src/app/casedetail/casedetail.page.html
@@ -18,8 +18,8 @@
       Related Topics
     </div>
   </ion-text>
-  <ion-list *ngFor="let topic of relatedTopics" [routerLink]="['topics/detail', topic.id]">
-    <ion-item>
+  <ion-list>
+    <ion-item *ngFor="let topic of relatedTopics" [routerLink]="['topics/detail', topic.id]">
       <ion-thumbnail slot="start">
         <img src="../../assets/images/{{topic.id}}.svg" onerror="this.src='../../assets/shapes.svg'">
       </ion-thumbnail>

--- a/src/app/cases/cases.page.html
+++ b/src/app/cases/cases.page.html
@@ -10,8 +10,8 @@
       about.
     </div>
   </ion-text>
-  <ion-list *ngFor="let case of cases" [routerLink]="['detail', case.id]">
-    <ion-item>
+  <ion-list>
+    <ion-item *ngFor="let case of cases" [routerLink]="['detail', case.id]">
       <ion-label>
         <h3>{{ case.title }}</h3>
         <p [innerHTML]="case.snippet"></p>

--- a/src/app/cases/cases.page.ts
+++ b/src/app/cases/cases.page.ts
@@ -17,8 +17,4 @@ export class CasesPage implements OnInit {
   ngOnInit() {
     this.cases = this.data.cases;
   }
-
-  navigateToDetails(id: any) {
-    this.navCtrl.navigateForward('tabs/cases/detail/' + id);
-  }
 }

--- a/src/app/topicdetail/topicdetail.page.html
+++ b/src/app/topicdetail/topicdetail.page.html
@@ -18,8 +18,8 @@
       Related Cases
     </div>
   </ion-text>
-  <ion-list *ngFor="let case of linkedCases" [routerLink]="['cases/details', case.id]">
-    <ion-item>
+  <ion-list>
+    <ion-item *ngFor="let case of linkedCases" [routerLink]="['cases/details', case.id]">
       <ion-label>
         <h3>{{ case.title }}</h3>
         <p [innerHTML]="case.snippet"></p>

--- a/src/app/topicdetail/topicdetail.page.ts
+++ b/src/app/topicdetail/topicdetail.page.ts
@@ -12,7 +12,7 @@ import * as Data from '../../assets/data/data.json';
 export class TopicdetailPage implements OnInit {
   data: any = (Data as any).default;
   topic: { title: '', summary: '', content: '', cases: []};
-  linkedCases: [] = [];
+  linkedCases: any[] = [];
 
   constructor(
     private router: Router,
@@ -26,7 +26,7 @@ export class TopicdetailPage implements OnInit {
       this.topic = this.data.topics.find((topic) => topic.id === params.id);
 
       for (const caseId of this.topic.cases) {
-        const linkedCase = this.topic.cases.find((id) => id === caseId);
+        const linkedCase = this.data.cases.find((c) => c.id === caseId);
         this.linkedCases.push(linkedCase);
       }
     });

--- a/src/app/topics/topics.page.html
+++ b/src/app/topics/topics.page.html
@@ -11,8 +11,8 @@
       more about.
     </div>
   </ion-text>
-  <ion-list *ngFor="let topic of initialTopics"  [routerLink]="['detail', topic.id]">
-    <ion-item>
+  <ion-list>
+    <ion-item *ngFor="let topic of topics"  [routerLink]="['detail', topic.id]">
       <ion-thumbnail slot="start">
         <img src="../../assets/images/{{topic.id}}.svg" onerror="this.src='../../assets/shapes.svg'">
       </ion-thumbnail>
@@ -22,37 +22,4 @@
       </ion-label>
     </ion-item>
   </ion-list>
-  <ion-text>
-    <div class="ion-padding">
-      More Topics
-    </div>
-  </ion-text>
-  <ion-list *ngFor="let topic of topics" (click)="navigateToDetails(topic.id)">
-    <ion-item>
-      <ion-label>
-        <h3>{{ topic.title }}</h3>
-        <p [innerHTML]="topic.snippet"></p>
-      </ion-label>
-    </ion-item>
-  </ion-list>
-  <!-- <ion-card *ngFor="let topic of initialTopics" (click)="navigateToDetails(topic.id)">
-    <ion-grid>
-      <ion-row>
-        <ion-col size="3">
-        </ion-col>
-        <ion-col size="9">
-          <ion-card-header>
-            <ion-card-title>{{ topic.title }}</ion-card-title>
-          </ion-card-header>
-          <ion-card-content [innerHTML]="topic.snippet"></ion-card-content>
-        </ion-col>
-      </ion-row>
-    </ion-grid>
-  </ion-card>
-  <ion-title>More Topics</ion-title>
-  <ion-content>
-    <ion-row class="more-topics-list" *ngFor="let topic of topics" (click)="navigateToDetails(topic.id)">
-      <ion-text>{{ topic.title }}: {{topic.snippet}}</ion-text>
-    </ion-row>
-  </ion-content> -->
 </ion-content>

--- a/src/app/topics/topics.page.ts
+++ b/src/app/topics/topics.page.ts
@@ -11,16 +11,10 @@ import * as Data from '../../assets/data/data.json';
 export class TopicsPage implements OnInit {
   data: any = (Data as any).default;
   topics: [];
-  initialTopics = [];
 
   constructor(private router: Router, private navCtrl: NavController) { }
 
   ngOnInit() {
-    this.initialTopics = this.data.topics.slice(0, 10);
-    this.topics = this.data.topics.slice(10, this.data.topics.length);
-  }
-
-  navigateToDetails(id: any) {
-    this.navCtrl.navigateForward('tabs/topics/detail/' + id);
+    this.topics = this.data.topics;
   }
 }


### PR DESCRIPTION
@fluenty this fixes some bugs

* correctly use ion-list and ion-item
* fix related case lookup for topics
* strip unused stuff on topic listing page

Please can you fix:

* clicking on a related case in the topic view breaks
* show related cases header and list only if there are any (see comments)