### PR TITLE
Make constitution text searchable

### DIFF
--- a/src/app/results/results.page.html
+++ b/src/app/results/results.page.html
@@ -9,6 +9,14 @@
   </ion-toolbar>
 </ion-header>
 <ion-content>
+  <ion-list>
+    <ion-item *ngFor="let provision of provisions">
+      <ion-label>
+        <h3>{{ provision.title }}</h3>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+
   <ion-card *ngFor="let case of cases" (click)="navigateCaseToDetails(case.id)">
     <ion-grid>
       <ion-row>

--- a/src/app/results/results.page.ts
+++ b/src/app/results/results.page.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import * as Data from "../../assets/data/data.json"
+import * as Data from "../../assets/data/data.json";
+import * as Constitution from '../../assets/data/constitution.json';
 
 @Component({
   selector: 'app-results',
@@ -10,18 +11,25 @@ import * as Data from "../../assets/data/data.json"
 })
 export class ResultsPage implements OnInit {
   data: any = (Data as any).default;
+  constitution: any = (Constitution as any).default;
+  searchableProvisions: {title: string, content: string, id: string}[];
   cases: [];
   topics: [];
-  term: String = "";
-  constructor(private router: Router, private route: ActivatedRoute, private location: Location) { }
+  provisions: {title: string, content: string, id: string}[];
+  term = '';
+
+  constructor(private router: Router, private route: ActivatedRoute, private location: Location) {
+    this.setupConstitutionSearch();
+  }
 
   ngOnInit() {
     this.route.params.subscribe(params => {
-      this.term = params['term'];
+      this.term = params.term;
+      const needle = this.term.toLocaleLowerCase();
 
-      this.cases = this.data.cases.filter((x) => x.title.toLowerCase().includes(params['term'])|| (x.summary ? x.summary.includes(params["term"]) : null))
-      this.topics = this.data.topics.filter((x) => x.title.toLowerCase().includes(params['term']) || (x.summary ? x.summary.includes(params["term"]) : null))
-
+      this.cases = this.data.cases.filter((x) => x.title.toLowerCase().includes(needle) || (x.summary ? x.summary.includes(needle) : null));
+      this.topics = this.data.topics.filter((x) => x.title.toLowerCase().includes(needle) || (x.summary ? x.summary.includes(needle) : null));
+      this.provisions = this.searchableProvisions.filter((x) => x.title.includes(needle) || x.content.includes(needle));
     });
   }
 
@@ -35,5 +43,29 @@ export class ResultsPage implements OnInit {
 
   navigateCaseToDetails(id: any) {
     this.router.navigateByUrl('tabs/case/detail/' + id);
+  }
+
+  /**
+   * Setup a list of provisions that we can search, which are all the sections of the constitution
+   */
+  setupConstitutionSearch() {
+    // everything that can contain searchable text
+    const selector = '.akn-p, .akn-listIntroduction, .akn-intro, .akn-wrapUp';
+    const body = new DOMParser().parseFromString(this.constitution.body, 'text/html');
+    this.searchableProvisions = [];
+
+    body.querySelectorAll('.akn-section').forEach(section => {
+      // gather text content
+      const text = [];
+      section.querySelectorAll(selector).forEach(elem => {
+        text.push(elem.textContent);
+      });
+
+      this.searchableProvisions.push({
+        title: section.querySelector('h3').textContent.toLocaleLowerCase(),
+        content: text.join(' ').toLocaleLowerCase(),
+        id: section.id
+      });
+    });
   }
 }

--- a/src/app/results/results.page.ts
+++ b/src/app/results/results.page.ts
@@ -12,10 +12,10 @@ import * as Constitution from '../../assets/data/constitution.json';
 export class ResultsPage implements OnInit {
   data: any = (Data as any).default;
   constitution: any = (Constitution as any).default;
-  searchableProvisions: {title: string, content: string, id: string}[];
+  searchableProvisions: {title: string, content: string, id: string, titleLower: string}[];
   cases: [];
   topics: [];
-  provisions: {title: string, content: string, id: string}[];
+  provisions: {title: string, content: string, id: string, titleLower: string}[];
   term = '';
 
   constructor(private router: Router, private route: ActivatedRoute, private location: Location) {
@@ -29,7 +29,7 @@ export class ResultsPage implements OnInit {
 
       this.cases = this.data.cases.filter((x) => x.title.toLowerCase().includes(needle) || (x.summary ? x.summary.includes(needle) : null));
       this.topics = this.data.topics.filter((x) => x.title.toLowerCase().includes(needle) || (x.summary ? x.summary.includes(needle) : null));
-      this.provisions = this.searchableProvisions.filter((x) => x.title.includes(needle) || x.content.includes(needle));
+      this.provisions = this.searchableProvisions.filter((x) => x.titleLower.includes(needle) || x.content.includes(needle));
     });
   }
 
@@ -60,9 +60,11 @@ export class ResultsPage implements OnInit {
       section.querySelectorAll(selector).forEach(elem => {
         text.push(elem.textContent);
       });
+      const title = section.querySelector('h3').textContent;
 
       this.searchableProvisions.push({
-        title: section.querySelector('h3').textContent.toLocaleLowerCase(),
+        titleLower: title.toLocaleLowerCase(),
+        title: title,
         content: text.join(' ').toLocaleLowerCase(),
         id: section.id
       });


### PR DESCRIPTION
This adds very basic functionality to make the provisions of the constitution show up in search results. Outstanding (but will be added later):

* adjust how search results are shown
* make provisions clickable to take the user to the identified section

![image](https://user-images.githubusercontent.com/4178542/96240649-73177300-0fa1-11eb-9a79-872ca9273e6a.png)
